### PR TITLE
Make readable-cdb open files as ro

### DIFF
--- a/src/readable-cdb.js
+++ b/src/readable-cdb.js
@@ -16,7 +16,7 @@ var readable = module.exports = function(file) {
 readable.prototype.open = function(callback) {
     var self = this;
 
-    fs.open(this.file, 'r+', readHeader);
+    fs.open(this.file, 'r', readHeader);
 
     function readHeader(err, fd) {
         if (err) {


### PR DESCRIPTION
Readable CDB opens the file as r+, which causes problems with read-only file systems. Because the reader is read-only, r+ is useless, so I propose to change it to r.